### PR TITLE
input validation

### DIFF
--- a/RoR2VersionSelector/RoR2VersionSelector.cs
+++ b/RoR2VersionSelector/RoR2VersionSelector.cs
@@ -91,9 +91,31 @@ namespace RoR2VersionSelector
             UpdateInitialState();
         }
 
+        private Boolean ValidateInput()
+        {
+            if (TextBoxUsername.Text.Length == 0)
+            {
+                MessageBox.Show("Please specify username.", "Invalid", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return false;
+            }
+
+            if (!Enum.IsDefined(typeof(RoR2Versions), ComboBoxVersionSelector.Text))
+            {
+                MessageBox.Show("Please specify valid version.", "Invalid", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return false;
+            }
+
+            return true;
+        }
+
         private async void ButtonDownloadDepot_Click(object sender, EventArgs e)
         {
+            if (!ValidateInput())
+            {
+                return;
+            }
             ButtonDownloadDepot.Enabled = false;
+
 
             var startInfo = new ProcessStartInfo
             {


### PR DESCRIPTION
input validation when clicking download.

Current problem is if you don't specify a username the next argument is parsed due to no string (which comes to -dir)

This enforces that the command line application will not launch until a username is provided, and as a bonus, that a valid RoR version is specified, since the dropdownlist is also a textbox.